### PR TITLE
SVC-3240: Fix discovered PHP timezone issue

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -17,7 +17,8 @@ profile_website::monitoring::telegraf_sslcert_check_file: "/etc/telegraf/telegra
 profile_website::monitoring::telegraf_website_check_file: "/etc/telegraf/telegraf.d/website-check.conf"
 
 profile_website::php::ini_file: "/etc/php.d/00-puppet.ini"
-profile_website::php::ini_settings: {}
+profile_website::php::ini_settings:
+  date.timezone: "America/Chicago"
 
 profile_website::ssl::certificate_files: {}
 profile_website::ssl::enable_letsencrypt: true


### PR DESCRIPTION
Add America/Chicago timezone to PHP settings by default

This is being tested on the following servers:
- `asd-test-web2`
- `users`