### PR TITLE
ASDPLNG-133: Lookup docroot for temporary letsencrypt httpd config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 .project
 .envrc
 /inventory.yaml
+/spec/fixtures/litmus_inventory.yaml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,11 +19,11 @@ default:
     - bundle -v
     - bundle install --without system_tests --path vendor/bundle --jobs $(nproc)
 
-syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop-Ruby 2.5.7-Puppet ~> 6:
+validate lint check rubocop-Ruby 2.5.7-Puppet ~> 6:
   stage: syntax
   image: ruby:2.5.7
   script:
-    - bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
+    - bundle exec rake validate lint check rubocop
   variables:
     PUPPET_GEM_VERSION: '~> 6'
 
@@ -34,4 +34,20 @@ parallel_spec-Ruby 2.5.7-Puppet ~> 6:
     - bundle exec rake parallel_spec
   variables:
     PUPPET_GEM_VERSION: '~> 6'
+
+validate lint check rubocop-Ruby 2.7.2-Puppet ~> 7:
+  stage: syntax
+  image: ruby:2.7.2
+  script:
+    - bundle exec rake validate lint check rubocop
+  variables:
+    PUPPET_GEM_VERSION: '~> 7'
+
+parallel_spec-Ruby 2.7.2-Puppet ~> 7:
+  stage: unit
+  image: ruby:2.7.2
+  script:
+    - bundle exec rake parallel_spec
+  variables:
+    PUPPET_GEM_VERSION: '~> 7'
 

--- a/.pdkignore
+++ b/.pdkignore
@@ -25,7 +25,9 @@
 .project
 .envrc
 /inventory.yaml
+/spec/fixtures/litmus_inventory.yaml
 /appveyor.yml
+/.editorconfig
 /.fixtures.yml
 /Gemfile
 /.gitattributes
@@ -42,3 +44,4 @@
 /spec/
 /.vscode/
 /.sync.yml
+/.devcontainer/

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
   fast_finish: true
   include:
     -
-      env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
+      env: CHECK="validate lint check rubocop"
       stage: static
     -
       env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec

--- a/Gemfile
+++ b/Gemfile
@@ -44,16 +44,6 @@ gems['puppet'] = location_for(puppet_version)
 gems['facter'] = location_for(facter_version) if facter_version
 gems['hiera'] = location_for(hiera_version) if hiera_version
 
-if Gem.win_platform? && puppet_version =~ %r{^(file:///|git://)}
-  # If we're using a Puppet gem on Windows which handles its own win32-xxx gem
-  # dependencies (>= 3.5.0), set the maximum versions (see PUP-6445).
-  gems['win32-dir'] =      ['<= 0.4.9', require: false]
-  gems['win32-eventlog'] = ['<= 0.6.5', require: false]
-  gems['win32-process'] =  ['<= 0.7.5', require: false]
-  gems['win32-security'] = ['<= 0.2.5', require: false]
-  gems['win32-service'] =  ['0.8.8', require: false]
-end
-
 gems.each do |gem_name, gem_params|
   gem gem_name, *gem_params
 end

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ To install and configure:
 
 The following [`apache`](https://forge.puppet.com/modules/puppetlabs/apache/reference) parameters need to be set:
 ```
-apache::default_ssl_cert: "/etc/letsencrypt/live/%{facts.fqdn}/fullchain.pem"
+apache::default_ssl_cert: "/etc/letsencrypt/live/%{facts.fqdn}/cert.pem"
+apache::default_ssl_chain: "/etc/letsencrypt/live/%{facts.fqdn}/chain.pem"
 apache::default_ssl_key: "/etc/letsencrypt/live/%{facts.fqdn}/privkey.pem"
 apache::mod::ssl:
   # WITH PARAMETERS

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 ---
 version: 1.1.x.{build}
+skip_branch_with_pr: true
 branches:
   only:
     - main
@@ -17,7 +18,7 @@ environment:
   matrix:
     -
       RUBY_VERSION: 25-x64
-      CHECK: syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
+      CHECK: validate lint check rubocop
     -
       PUPPET_GEM_VERSION: ~> 6.0
       RUBY_VERSION: 25

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
       "version_requirement": ">= 6.21.0 < 8.0.0"
     }
   ],
-  "pdk-version": "2.0.0",
-  "template-url": "pdk-default#2.0.0",
-  "template-ref": "tags/2.0.0-0-ge838f1d"
+  "pdk-version": "2.2.0",
+  "template-url": "pdk-default#2.2.0",
+  "template-ref": "tags/2.2.0-0-g2381db6"
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,18 @@ RSpec.configure do |c|
   c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
   c.after(:suite) do
   end
+
+  # Filter backtrace noise
+  backtrace_exclusion_patterns = [
+    %r{spec_helper},
+    %r{gems},
+  ]
+
+  if c.respond_to?(:backtrace_exclusion_patterns)
+    c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
+  elsif c.respond_to?(:backtrace_clean_patterns)
+    c.backtrace_clean_patterns = backtrace_exclusion_patterns
+  end
 end
 
 # Ensures that a module is defined


### PR DESCRIPTION
Add requires for docroot for initial lets encrypt request of cert
Upgrade PDK
Update README example to use both default_ssl_cert & default_ssl_chain

Discovered a bug in `vhost.pp` logic for the `docroot` setting if using Let's Encrypt but not yet have the certificate. The `docroot` needs to be looked up from the `vhost` hiera data for the SSL version of the website.

This is being tested on: `its-repo`