### PR TITLE
ASDPLNG-141: Update php subclass to support specific php extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ apache::vhost:
 
 ## Dependencies
 - [puppet/letsencrypt](https://forge.puppet.com/modules/puppet/letsencrypt)
+- [puppet/php](https://forge.puppet.com/modules/puppet/php/)
 - [puppetlabs/apache](https://forge.puppet.com/modules/puppetlabs/apache)
 - [puppetlabs/firewall](https://forge.puppet.com/puppetlabs/firewall)
 - [puppetlabs/stdlib](https://forge.puppet.com/modules/puppetlabs/stdlib)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -132,9 +132,9 @@ The following parameters are available in the `profile_website::php` class:
 
 * [`auto_prepend_file`](#auto_prepend_file)
 * [`auto_prepend_file_content`](#auto_prepend_file_content)
+* [`enable`](#enable)
 * [`ini_file`](#ini_file)
-* [`ini_settings`](#ini_settings)
-* [`timezone`](#timezone)
+* [`version`](#version)
 
 ##### <a name="auto_prepend_file"></a>`auto_prepend_file`
 
@@ -148,23 +148,23 @@ Data type: `String`
 
 Contents of auto_prepend_file
 
+##### <a name="enable"></a>`enable`
+
+Data type: `Boolean`
+
+Whether to enable PHP for this website
+
 ##### <a name="ini_file"></a>`ini_file`
 
 Data type: `String`
 
 Full path to default ini_file where PHP settings are set
 
-##### <a name="ini_settings"></a>`ini_settings`
-
-Data type: `Hash[String, String]`
-
-Key value pairs of desired PHP settings
-
-##### <a name="timezone"></a>`timezone`
+##### <a name="version"></a>`version`
 
 Data type: `String`
 
-String of timezone
+Version of PHP to install/enable via DNF module (RHEL >= 8)
 
 ### <a name="profile_websitessl"></a>`profile_website::ssl`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,14 @@
 ---
+php::ensure: "present"
+php::fpm: true
+php::pear: true
+php::phpunit: false
+php::settings:
+  "expose_php": "Off"
+  "date.timezone": "America/Chicago"
+  "auto_prepend_file": "/usr/share/php/prepend.php"
+php::extensions: {}
+
 profile_website::firewall::http_allowed_subnets:
   "public": "0.0.0.0/0"
   #"NCSA private": "172.24.0.0/13"
@@ -25,9 +35,9 @@ profile_website::php::auto_prepend_file_content: |
     unset($_SERVER['HTTP_AUTHORIZATION']);
     unset($_SERVER['PHP_AUTH_PW']);
   ?>
-profile_website::php::ini_file: "/etc/php.d/00-puppet.ini"
-profile_website::php::ini_settings: {}
-profile_website::php::timezone: "America/Chicago"
+profile_website::php::enable: false
+profile_website::php::ini_file: "/etc/php.ini"
+profile_website::php::version: "7.2"
 
 profile_website::ssl::certificate_files: {}
 profile_website::ssl::enable_letsencrypt: true

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,0 +1,2 @@
+---
+profile_website::php::version: "7.2"

--- a/data/os/RedHat/8.yaml
+++ b/data/os/RedHat/8.yaml
@@ -1,0 +1,2 @@
+---
+profile_website::php::version: "7.4"

--- a/data/os/RedHat/9.yaml
+++ b/data/os/RedHat/9.yaml
@@ -1,0 +1,2 @@
+---
+profile_website::php::version: "8.0"

--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -6,86 +6,67 @@
 # @param auto_prepend_file_content
 #   Contents of auto_prepend_file
 #
+# @param enable
+#   Whether to enable PHP for this website
+#
 # @param ini_file
 #   Full path to default ini_file where PHP settings are set
 #
-# @param ini_settings
-#   Key value pairs of desired PHP settings
-#
-# @param timezone
-#   String of timezone
+# @param version
+#   Version of PHP to install/enable via DNF module (RHEL >= 8)
 #
 # @example
 #   include profile_website::php
 class profile_website::php (
   String               $auto_prepend_file,
   String               $auto_prepend_file_content,
+  Boolean              $enable,
   String               $ini_file,
-  Hash[String, String] $ini_settings,
-  String               $timezone,
+  String               $version,
 ) {
 
-  if ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] >= '8') {
-    # USE 7.4 VERSION OF YUM/DNF PHP MODULE
-    $dnf_php_command = 'dnf -y module reset php && dnf -y module enable php:7.4'
-    exec { 'ensure_dnf_php_module_7.4':
-      path    => ['/bin', '/usr/bin', '/usr/sbin'],
-      unless  => 'dnf module list php | grep 7.4 | egrep -i \'7.4 \[[e|d]\]\'',
-      command => $dnf_php_command,
-    }
-  }
+  if $enable {
 
-  include ::apache::mod::php
-  ## IF IN FUTURE WE SET PARAMETERS
-  #ensure_resource( 'class', '::apache::mod::php', lookup('apache::mod::php') )
-
-  File_line {
-    ensure => 'present',
-  }
-
-  file { $ini_file:
-    ensure => 'present',
-    mode   => '0644',
-  }
-  if ($ini_settings)
-  {
-    $ini_settings.each | $k, $v | {
-      ## NOTE THAT THIS DOES NOT CLEAN UP HISTORICAL SETTINGS THAT ARE REMOVED
-      file_line { "${ini_file} ${k} = ${v}":
-        path    => $ini_file,
-        replace => true,
-        line    => "${k} = ${v}",
-        match   => "${k}.*",
-        notify  => Class['apache::service'],
+    if ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] >= '8') {
+      # SELECT SPECIFIC VERSION OF PHP VIA DNF MODULE SETTINGS
+      $dnf_php_command = "dnf -y module reset php && dnf -y module enable php:${version}"
+      exec { "ensure_dnf_php_module_${version}":
+        path    => ['/bin', '/usr/bin', '/usr/sbin'],
+        unless  => "dnf module list php | grep ${version} | egrep -i \'${version} \\[[e|d]\\]\'",
+        command => $dnf_php_command,
       }
     }
-  }
 
-  file_line { 'PHP disable expose_php':
-    line   => 'expose_php = Off',
-    match  => '^expose_php = .*$',
-    path   => $ini_file,
-    notify => Class['apache::service'],
-  }
-  file_line { 'PHP set timezone':
-    line   => "date.timezone = ${timezone}",
-    match  => '^date-timezone = .*$',
-    path   => $ini_file,
-    notify => Class['apache::service'],
-  }
-  file_line { 'PHP set auto_prepend_file':
-    line   => "auto_prepend_file = ${auto_prepend_file}",
-    match  => '^auto_prepend_file = .*$',
-    path   => $ini_file,
-    notify => Class['apache::service'],
-  }
-  file { $auto_prepend_file:
-    ensure  => file,
-    content => $auto_prepend_file_content,
-    mode    => '0644',
-    owner   => root,
-    group   => root,
-    notify  => Class['apache::service'],
+    include ::apache::mod::php
+    include ::php
+
+    file { $auto_prepend_file:
+      ensure  => file,
+      content => $auto_prepend_file_content,
+      mode    => '0644',
+      owner   => root,
+      group   => root,
+      notify  => Class['apache::service'],
+    }
+
+    file { $ini_file:
+      ensure => 'present',
+      mode   => '0644',
+    }
+
+    # PHP MODULE WASN'T UPDATING THE VALUES IN /etc/php.ini AS EXPECTED
+    $::php::settings.each | $setting, $value |
+    {
+      ini_setting { "${ini_file} ${setting} = ${value}":
+        ensure  => present,
+        path    => $ini_file,
+        section => 'PHP',
+        setting => $setting,
+        value   => $value,
+        notify  => Service['php-fpm'],
+      }
+    }
+
   }
 
 }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -44,6 +44,15 @@ class profile_website::vhost {
       withpath => true,
     }
 
+    # THE FOLLOWING WILL BE REMOVED ONCE LETS ENCRYPT OBTAINS ITS FIRST CERTIFICATE
+    firewall { '400 temporarily allow HTTP on tcp port 80 for letsencrypt':
+      dport  => '80',
+      proto  => tcp,
+      source => '0.0.0.0/0',
+      action => accept,
+      before => Class['letsencrypt'],
+    }
+
     $vhost = lookup('apache::vhost', Hash)
     $ssl_vhost_name = String("${facts['fqdn']}-ssl")
     $servername = $vhost[$ssl_vhost_name]['servername']
@@ -69,6 +78,7 @@ class profile_website::vhost {
       error_log_pipe  => "|/bin/sh -c '/usr/bin/tee \
         -a /var/log/httpd/${facts['fqdn']}-nossl_error.log' \
         |/bin/sh -c '/usr/bin/logger -t httpd -p local6.err'",
+      before          => Class['letsencrypt'],
     }
   }
 


### PR DESCRIPTION
```
Use puppet/php module
Make php optional, not installing and configuring it by default
Add in code to ensure php settings in php.ini
Ensure firewall open on port 80 for LetsEncrypt to obtain first cert
```

This is driven by needs in https://jira.ncsa.illinois.edu/browse/SVCPLAN-141

This has been tested on `cmdb-dev-kimber7`.