### PR TITLE
SVCPLAN-1450: Fix when creating static SSL certs

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,38 @@
+# devcontainer
+
+
+For format details, see https://aka.ms/devcontainer.json. 
+
+For config options, see the README at:
+https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
+ 
+``` json
+{
+	"name": "Puppet Development Kit (Community)",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash",
+			}
+		}
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"puppet.puppet-vscode",
+		"rebornix.Ruby"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pdk --version",
+}
+```
+
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,17 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
 {
 	"name": "Puppet Development Kit (Community)",
 	"dockerFile": "Dockerfile",
 
-	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash"
+			}
+		}
 	},
 
-	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"puppet.puppet-vscode",
 		"rebornix.Ruby"
 	]
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pdk --version",
 }

--- a/.github/workflows/pdk-validate.yml
+++ b/.github/workflows/pdk-validate.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Clone repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Run pdk validate"
         uses: "puppets-epic-show-theatre/action-pdk-validate@v1"
         with:

--- a/.pdkignore
+++ b/.pdkignore
@@ -39,7 +39,6 @@
 /rakelib/
 /.rspec
 /.rubocop.yml
-/.travis.yml
 /.yardopts
 /spec/
 /.vscode/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
 - rubocop-rspec
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.4'
+  TargetRubyVersion: '2.5'
   Include:
   - "**/*.rb"
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -13,21 +13,31 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
-ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
-minor_version = ruby_version_segments[0..1].join('.')
-
 group :development do
-  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "json", '= 2.1.0',                           require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0',                           require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.5.1',                           require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.1',                           require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.3',                           require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "voxpupuli-puppet-lint-plugins", '~> 4.0',   require: false
+  gem "facterdb", '~> 1.18',                       require: false
+  gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0', require: false
+  gem "puppetlabs_spec_helper", '~> 5.0',          require: false
+  gem "rspec-puppet-facts", '~> 2.0',              require: false
+  gem "codecov", '~> 0.2',                         require: false
+  gem "dependency_checker", '~> 0.2',              require: false
+  gem "parallel_tests", '= 3.12.1',                require: false
+  gem "pry", '~> 0.10',                            require: false
+  gem "simplecov-console", '~> 0.5',               require: false
+  gem "puppet-debugger", '~> 1.0',                 require: false
+  gem "rubocop", '= 1.6.1',                        require: false
+  gem "rubocop-performance", '= 1.9.1',            require: false
+  gem "rubocop-rspec", '= 2.0.1',                  require: false
+  gem "rb-readline", '= 0.5.5',                    require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby, :x64_mingw]
+  gem "serverspec", '~> 2.41',    require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/README.md
+++ b/README.md
@@ -104,6 +104,30 @@ apache::vhost:
         rewrite_rule: "(.*)  https://%%{}{SERVER_NAME}/$1 [R,L]"
 ```
 
+If you are using a traditional SSL certificate (rather than via LetsEncrypt) you need to provide the certificates via the following parameters:
+```yaml
+apache::default_ssl_cert: "/etc/pki/tls/certs/%{facts.fqdn}.cer"
+apache::default_ssl_chain: "/etc/pki/tls/certs/%{facts.fqdn}.interm.cer"
+apache::default_ssl_key: "/etc/pki/tls/private/%{facts.fqdn}.key"
+
+profile_website::kerberos::enable: false
+
+# FOLLOWING CERTIFICATE FILES CONTENT SHOULD BE ENCRYPTED
+profile_website::ssl::certificate_files:
+  "/etc/pki/tls/certs/%{facts.fqdn}.cer": |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+  "/etc/pki/tls/certs/%{facts.fqdn}.interm.cer": |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+  "/etc/pki/tls/private/%{facts.fqdn}.key": |
+    -----BEGIN PRIVATE KEY-----
+    ...
+    -----END PRIVATE KEY-----
+```
+
 ## Dependencies
 - [puppet/letsencrypt](https://forge.puppet.com/modules/puppet/letsencrypt)
 - [puppet/php](https://forge.puppet.com/modules/puppet/php/)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,12 +7,12 @@
 ### Classes
 
 * [`profile_website`](#profile_website): Configure an Apache HTTPd website
-* [`profile_website::firewall`](#profile_websitefirewall): Open HTTPd ports in the firewall
-* [`profile_website::kerberos`](#profile_websitekerberos): Manage Kerberos HTTP Principal
-* [`profile_website::monitoring`](#profile_websitemonitoring): Register monitoring for the website
-* [`profile_website::php`](#profile_websitephp): Install and configure PHP
-* [`profile_website::ssl`](#profile_websitessl): Configure SSL certificates for apache httpd
-* [`profile_website::vhost`](#profile_websitevhost): Ensure apache::vhost configured
+* [`profile_website::firewall`](#profile_website--firewall): Open HTTPd ports in the firewall
+* [`profile_website::kerberos`](#profile_website--kerberos): Manage Kerberos HTTP Principal
+* [`profile_website::monitoring`](#profile_website--monitoring): Register monitoring for the website
+* [`profile_website::php`](#profile_website--php): Install and configure PHP
+* [`profile_website::ssl`](#profile_website--ssl): Configure SSL certificates for apache httpd
+* [`profile_website::vhost`](#profile_website--vhost): Ensure apache::vhost configured
 
 ## Classes
 
@@ -28,7 +28,7 @@ Configure an Apache HTTPd website
 include profile_website
 ```
 
-### <a name="profile_websitefirewall"></a>`profile_website::firewall`
+### <a name="profile_website--firewall"></a>`profile_website::firewall`
 
 Open HTTPd ports in the firewall
 
@@ -44,22 +44,22 @@ include profile_website::firewall
 
 The following parameters are available in the `profile_website::firewall` class:
 
-* [`http_allowed_subnets`](#http_allowed_subnets)
-* [`https_allowed_subnets`](#https_allowed_subnets)
+* [`http_allowed_subnets`](#-profile_website--firewall--http_allowed_subnets)
+* [`https_allowed_subnets`](#-profile_website--firewall--https_allowed_subnets)
 
-##### <a name="http_allowed_subnets"></a>`http_allowed_subnets`
+##### <a name="-profile_website--firewall--http_allowed_subnets"></a>`http_allowed_subnets`
 
 Data type: `Hash[String,String]`
 
 Subnets allowed access via http port
 
-##### <a name="https_allowed_subnets"></a>`https_allowed_subnets`
+##### <a name="-profile_website--firewall--https_allowed_subnets"></a>`https_allowed_subnets`
 
 Data type: `Hash[String,String]`
 
 Subnets allowed access via https port
 
-### <a name="profile_websitekerberos"></a>`profile_website::kerberos`
+### <a name="profile_website--kerberos"></a>`profile_website::kerberos`
 
 Manage Kerberos HTTP Principal
 
@@ -75,15 +75,22 @@ include profile_website::kerberos
 
 The following parameters are available in the `profile_website::kerberos` class:
 
-* [`http_keytab_file`](#http_keytab_file)
+* [`enable`](#-profile_website--kerberos--enable)
+* [`http_keytab_file`](#-profile_website--kerberos--http_keytab_file)
 
-##### <a name="http_keytab_file"></a>`http_keytab_file`
+##### <a name="-profile_website--kerberos--enable"></a>`enable`
+
+Data type: `Boolean`
+
+Whether or not kerberos keytab is enabled
+
+##### <a name="-profile_website--kerberos--http_keytab_file"></a>`http_keytab_file`
 
 Data type: `String`
 
 Full path to keytab file for http principal
 
-### <a name="profile_websitemonitoring"></a>`profile_website::monitoring`
+### <a name="profile_website--monitoring"></a>`profile_website::monitoring`
 
 Register monitoring for the website
 
@@ -99,22 +106,22 @@ include profile_website::monitoring
 
 The following parameters are available in the `profile_website::monitoring` class:
 
-* [`telegraf_sslcert_check_file`](#telegraf_sslcert_check_file)
-* [`telegraf_website_check_file`](#telegraf_website_check_file)
+* [`telegraf_sslcert_check_file`](#-profile_website--monitoring--telegraf_sslcert_check_file)
+* [`telegraf_website_check_file`](#-profile_website--monitoring--telegraf_website_check_file)
 
-##### <a name="telegraf_sslcert_check_file"></a>`telegraf_sslcert_check_file`
+##### <a name="-profile_website--monitoring--telegraf_sslcert_check_file"></a>`telegraf_sslcert_check_file`
 
 Data type: `String`
 
 Full path to telegraf sslcert check file
 
-##### <a name="telegraf_website_check_file"></a>`telegraf_website_check_file`
+##### <a name="-profile_website--monitoring--telegraf_website_check_file"></a>`telegraf_website_check_file`
 
 Data type: `String`
 
 Full path to telegraf website check file
 
-### <a name="profile_websitephp"></a>`profile_website::php`
+### <a name="profile_website--php"></a>`profile_website::php`
 
 Install and configure PHP
 
@@ -130,43 +137,43 @@ include profile_website::php
 
 The following parameters are available in the `profile_website::php` class:
 
-* [`auto_prepend_file`](#auto_prepend_file)
-* [`auto_prepend_file_content`](#auto_prepend_file_content)
-* [`enable`](#enable)
-* [`ini_file`](#ini_file)
-* [`version`](#version)
+* [`auto_prepend_file`](#-profile_website--php--auto_prepend_file)
+* [`auto_prepend_file_content`](#-profile_website--php--auto_prepend_file_content)
+* [`enable`](#-profile_website--php--enable)
+* [`ini_file`](#-profile_website--php--ini_file)
+* [`version`](#-profile_website--php--version)
 
-##### <a name="auto_prepend_file"></a>`auto_prepend_file`
+##### <a name="-profile_website--php--auto_prepend_file"></a>`auto_prepend_file`
 
 Data type: `String`
 
 Full path to default auto_prepend_file
 
-##### <a name="auto_prepend_file_content"></a>`auto_prepend_file_content`
+##### <a name="-profile_website--php--auto_prepend_file_content"></a>`auto_prepend_file_content`
 
 Data type: `String`
 
 Contents of auto_prepend_file
 
-##### <a name="enable"></a>`enable`
+##### <a name="-profile_website--php--enable"></a>`enable`
 
 Data type: `Boolean`
 
 Whether to enable PHP for this website
 
-##### <a name="ini_file"></a>`ini_file`
+##### <a name="-profile_website--php--ini_file"></a>`ini_file`
 
 Data type: `String`
 
 Full path to default ini_file where PHP settings are set
 
-##### <a name="version"></a>`version`
+##### <a name="-profile_website--php--version"></a>`version`
 
 Data type: `String`
 
 Version of PHP to install/enable via DNF module (RHEL >= 8)
 
-### <a name="profile_websitessl"></a>`profile_website::ssl`
+### <a name="profile_website--ssl"></a>`profile_website::ssl`
 
 Configure SSL certificates for apache httpd
 
@@ -182,22 +189,22 @@ include profile_website::ssl
 
 The following parameters are available in the `profile_website::ssl` class:
 
-* [`certificate_files`](#certificate_files)
-* [`enable_letsencrypt`](#enable_letsencrypt)
+* [`certificate_files`](#-profile_website--ssl--certificate_files)
+* [`enable_letsencrypt`](#-profile_website--ssl--enable_letsencrypt)
 
-##### <a name="certificate_files"></a>`certificate_files`
+##### <a name="-profile_website--ssl--certificate_files"></a>`certificate_files`
 
 Data type: `Hash[String,String]`
 
 Certificate files and contents for manually configured certificates
 
-##### <a name="enable_letsencrypt"></a>`enable_letsencrypt`
+##### <a name="-profile_website--ssl--enable_letsencrypt"></a>`enable_letsencrypt`
 
 Data type: `Boolean`
 
 Enable Let’s Encrypt for ssl certificate management
 
-### <a name="profile_websitevhost"></a>`profile_website::vhost`
+### <a name="profile_website--vhost"></a>`profile_website::vhost`
 
 Ensure apache::vhost configured
 

--- a/Rakefile
+++ b/Rakefile
@@ -43,6 +43,7 @@ end
 
 PuppetLint.configuration.send('disable_relative')
 
+
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -21,6 +21,7 @@ profile_website::firewall::https_allowed_subnets:
   #"NCSA public": "141.142.0.0/16"
   #"SSLlabs testing": "64.41.200.96/28"
 
+profile_website::kerberos::enable: true
 profile_website::kerberos::http_keytab_file: "/etc/httpd/conf/keytab"
 
 profile_website::monitoring::telegraf_sslcert_check_file: "/etc/telegraf/telegraf.d/sslcert-check.conf"

--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -12,9 +12,7 @@ class profile_website::firewall (
   Hash[String,String] $http_allowed_subnets,
   Hash[String,String] $https_allowed_subnets,
 ) {
-
-  $http_allowed_subnets.each | $location, $source_cidr |
-  {
+  $http_allowed_subnets.each | $location, $source_cidr | {
     firewall { "400 allow HTTP on tcp port 80 from ${location}":
       dport  => '80',
       proto  => tcp,
@@ -23,8 +21,7 @@ class profile_website::firewall (
     }
   }
 
-  $https_allowed_subnets.each | $location, $source_cidr |
-  {
+  $https_allowed_subnets.each | $location, $source_cidr | {
     firewall { "400 allow HTTPS on tcp port 443 from ${location}":
       dport  => '443',
       proto  => tcp,
@@ -32,5 +29,4 @@ class profile_website::firewall (
       action => accept,
     }
   }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,17 +4,16 @@
 #   include profile_website
 class profile_website (
 ) {
-
-  include ::apache
-  include ::apache::mod::alias
-  include ::apache::mod::autoindex
-  include ::apache::mod::ldap
+  include apache
+  include apache::mod::alias
+  include apache::mod::autoindex
+  include apache::mod::ldap
   ## IF IN FUTURE WE SET PARAMETERS
   #ensure_resource( 'class', '::apache::mod::ldap', lookup('apache::mod::ldap') )
   #include ::apache::mod::proxy
   ensure_resource( 'class', '::apache::mod::proxy', lookup('apache::mod::proxy') )
-  include ::apache::mod::proxy_http
-  include ::apache::mod::proxy_wstunnel
+  include apache::mod::proxy_http
+  include apache::mod::proxy_wstunnel
 
 #  include ::apache::mod::auth_openidc
   include profile_website::firewall
@@ -23,5 +22,4 @@ class profile_website (
   include profile_website::php
   include profile_website::ssl
   include profile_website::vhost
-
 }

--- a/manifests/kerberos.pp
+++ b/manifests/kerberos.pp
@@ -1,42 +1,46 @@
 # @summary Manage Kerberos HTTP Principal
 #
+# @param enable
+#   Whether or not kerberos keytab is enabled
+#
 # @param http_keytab_file
 #   Full path to keytab file for http principal
 #
 # @example
 #   include profile_website::kerberos
 class profile_website::kerberos (
+  Boolean $enable,
   String $http_keytab_file,
 ) {
+  if $enable {
+    include apache::mod::auth_gssapi
+    ## IF IN FUTURE WE SET PARAMETERS
+    #ensure_resource( 'class', '::apache::mod::auth_gssapi', lookup('apache::mod::auth_gssapi') )
 
-  include ::apache::mod::auth_gssapi
-  ## IF IN FUTURE WE SET PARAMETERS
-  #ensure_resource( 'class', '::apache::mod::auth_gssapi', lookup('apache::mod::auth_gssapi') )
+    ## SEE https://wiki.ncsa.illinois.edu/display/SecOps/Apache+-+Kerberos+Authentication+and+LDAP+Authorization
 
-  ## SEE https://wiki.ncsa.illinois.edu/display/SecOps/Apache+-+Kerberos+Authentication+and+LDAP+Authorization
+    # SHOULD WE REKEY THESE OCCASIONALLY ?
 
-  # SHOULD WE REKEY THESE OCCASIONALLY ?
+    # KRB COMMAND STRINGS
+    $kadmin_query = "kadmin -k -p host/${facts['networking']['fqdn']} -q"
+    $http_principal = "HTTP/${facts['networking']['fqdn']}"
 
-  # KRB COMMAND STRINGS
-  $kadmin_query = "kadmin -k -p host/${facts['fqdn']} -q"
-  $http_principal = "HTTP/${facts['fqdn']}"
+    exec { 'ensure_http_principal':
+      path    => ['/bin', '/usr/bin', '/usr/sbin'],
+      unless  => [
+        "${kadmin_query} \"getprinc ${http_principal}\" | grep -i HTTP",
+      ],
+      command => "${kadmin_query} \"addprinc -randkey ${http_principal}\" && rm -f \"${http_keytab_file}\"",
+      notify  => Exec['ensure_http_keytab'],
+    }
 
-  exec { 'ensure_http_principal':
-    path    => ['/bin', '/usr/bin', '/usr/sbin'],
-    unless  => [
-      "${kadmin_query} \"getprinc ${http_principal}\" | grep -i HTTP",
-    ],
-    command => "${kadmin_query} \"addprinc -randkey ${http_principal}\" && rm -f \"${http_keytab_file}\"",
-    notify  => Exec['ensure_http_keytab'],
+    exec { 'ensure_http_keytab':
+      path    => ['/bin', '/usr/bin', '/usr/sbin'],
+      unless  => [
+        "klist -ek ${http_keytab_file} | grep -i Principal",
+      ],
+      command => "${kadmin_query} \"ktadd -e aes256-cts -k ${http_keytab_file} ${http_principal}\"",
+      require => Exec['ensure_http_principal'],
+    }
   }
-
-  exec { 'ensure_http_keytab':
-    path    => ['/bin', '/usr/bin', '/usr/sbin'],
-    unless  => [
-      "klist -ek ${http_keytab_file} | grep -i Principal",
-    ],
-    command => "${kadmin_query} \"ktadd -e aes256-cts -k ${http_keytab_file} ${http_principal}\"",
-    require => Exec['ensure_http_principal'],
-  }
-
 }

--- a/manifests/monitoring.pp
+++ b/manifests/monitoring.pp
@@ -12,13 +12,12 @@ class profile_website::monitoring (
   String $telegraf_sslcert_check_file,
   String $telegraf_website_check_file,
 ) {
-
   # Set exported resource to populate telegraf sslcert check via ::profile_monitoring::telegraf_sslcert_check
-  @@file_line { "exported_telegraf_sslcert_check_${facts['fqdn']}":
+  @@file_line { "exported_telegraf_sslcert_check_${facts['networking']['fqdn']}":
     ensure   => 'present',
     after    => 'sources',
-    line     => "    \"https://${facts['fqdn']}:443\",",
-    match    => $facts['fqdn'],
+    line     => "    \"https://${facts['networking']['fqdn']}:443\",",
+    match    => $facts['networking']['fqdn'],
     multiple => 'false',
     notify   => Service['telegraf'],
     path     => $telegraf_sslcert_check_file,
@@ -26,15 +25,14 @@ class profile_website::monitoring (
   }
 
   # Set exported resource to populate telegraf ping check via ::profile_monitoring::telegraf_website_check
-  @@file_line { "exported_telegraf_website_check_${facts['fqdn']}":
+  @@file_line { "exported_telegraf_website_check_${facts['networking']['fqdn']}":
     ensure   => 'present',
     after    => 'urls',
-    line     => "    \"https://${facts['fqdn']}\",",
-    match    => $facts['fqdn'],
+    line     => "    \"https://${facts['networking']['fqdn']}\",",
+    match    => $facts['networking']['fqdn'],
     multiple => 'false',
     notify   => Service['telegraf'],
     path     => $telegraf_website_check_file,
     tag      => 'telegraf_website_check',
   }
-
 }

--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -24,9 +24,7 @@ class profile_website::php (
   String               $ini_file,
   String               $version,
 ) {
-
   if $enable {
-
     if ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] >= '8') {
       # SELECT SPECIFIC VERSION OF PHP VIA DNF MODULE SETTINGS
       $dnf_php_command = "dnf -y module reset php && dnf -y module enable php:${version}"
@@ -37,8 +35,8 @@ class profile_website::php (
       }
     }
 
-    include ::apache::mod::php
-    include ::php
+    include apache::mod::php
+    include php
 
     file { $auto_prepend_file:
       ensure  => file,
@@ -50,13 +48,12 @@ class profile_website::php (
     }
 
     file { $ini_file:
-      ensure => 'present',
+      ensure => 'file',
       mode   => '0644',
     }
 
     # PHP MODULE WASN'T UPDATING THE VALUES IN /etc/php.ini AS EXPECTED
-    $::php::settings.each | $setting, $value |
-    {
+    $php::settings.each | $setting, $value | {
       ini_setting { "${ini_file} ${setting} = ${value}":
         ensure  => present,
         path    => $ini_file,
@@ -66,7 +63,5 @@ class profile_website::php (
         notify  => Service['php-fpm'],
       }
     }
-
   }
-
 }

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -12,20 +12,19 @@ class profile_website::ssl (
   Hash[String,String] $certificate_files,
   Boolean             $enable_letsencrypt,
 ) {
-
   ensure_resource( 'class', '::apache::mod::ssl', lookup('apache::mod::ssl') )
 
   if $enable_letsencrypt {
-    include ::letsencrypt
+    include letsencrypt
 
     ## PULL apache::vhost DATA FOR $facts['fqdn']
     $vhost = lookup('apache::vhost', Hash)
-    $vhost_name = String("${facts['fqdn']}-ssl")
+    $vhost_name = String("${facts['networking']['fqdn']}-ssl")
     $servername = $vhost[$vhost_name]['servername']
     $serveraliases = $vhost[$vhost_name]['serveraliases']
-    $domains = unique( sort( [ $facts['fqdn'], $servername ] + $serveraliases ))
+    $domains = unique( sort([$facts['networking']['fqdn'], $servername] + $serveraliases ))
     $docroot = $vhost[$vhost_name]['docroot']
-    letsencrypt::certonly { $facts['fqdn']:
+    letsencrypt::certonly { $facts['networking']['fqdn']:
       domains       => $domains,
       plugin        => 'webroot',
       webroot_paths => [
@@ -40,10 +39,9 @@ class profile_website::ssl (
   elsif ( ! empty($certificate_files) ) {
     # READ HASH OF CERTIFICATE FILES AND CONTENTS FROM HIERA
     # CREATE EACH CERTIFICATE FILE WITH RESPECTIVE CONTENT
-    $certificate_files.each | $file, $content |
-    {
+    $certificate_files.each | $file, $content | {
       file { $file:
-        ensure  => present,
+        ensure  => file,
         owner   => root,
         group   => apache,
         mode    => '0640',
@@ -51,7 +49,7 @@ class profile_website::ssl (
         notify  => [
           Class['apache::service'],
           Class['profile_website::vhost'],
-        ]
+        ],
       }
     }
   }
@@ -66,5 +64,4 @@ class profile_website::ssl (
       withpath => true,
     }
   }
-
 }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -3,7 +3,6 @@
 # @example
 #   include profile_website::vhost
 class profile_website::vhost {
-
   # THIS IS A BIT TRICKY IN THAT ::letsencrypt NEEDS A WORKING APACHE CONFIG
   # IN ORDER TO CREATE THE INITIAL SSL CERTIFICATE
   # SO WE MAY NEED TO OVERRIDE THE apache::vhost LOOKUP PARAMETERS
@@ -25,12 +24,14 @@ class profile_website::vhost {
     }
   }
   elsif (
-    $default_ssl_cert in $facts['ssl_certificates']
-    and $default_ssl_key in $facts['ssl_keys']
+    ( $default_ssl_cert in $facts['ssl_certificates'] and $default_ssl_key in $facts['ssl_keys'] )
+    or
+    ( ! $profile_website::ssl::enable_letsencrypt and ! empty($profile_website::ssl::certificate_files) )
   ) {
     # DEFAULT SSL FILES EXIST, SO USE DEFAULT VHOST
     ensure_resources('apache::vhost', lookup('apache::vhost', {}) )
-  } else {
+  }
+  elsif ( $profile_website::ssl::enable_letsencrypt ) {
     # DEFAULT SSL FILES DO NOT EXIST,
     # SO USE TEMPORARY VHOST CONFIG THAT ALLOWS LETSENCRYPT TO GET SETUP
     #   POSSIBLE ALTERNATE SOLUTION: TEMPORARILY SET apache::default_vhost = true
@@ -38,10 +39,12 @@ class profile_website::vhost {
     ## NOTIFY THAT SSL FILES ARE MISSING SO USING TEMPORARY VHOST
     $notify_text = @("EOT"/)
       Default SSL certificate and/or key files are currently missing on this host.
-      Using an alternate apache::vhost configuration without SSL to temporary allow LetsEncrypt (if enabled) to create the SSL certificate.
+      Using an alternate apache::vhost configuration without SSL to temporary allow LetsEncrypt to create the SSL certificate.
+      You must run Puppet agent once more to use the LetsEncypt certificates that are being created.
       | EOT
     notify { $notify_text:
       withpath => true,
+      loglevel => 'warning',
     }
 
     # THE FOLLOWING WILL BE REMOVED ONCE LETS ENCRYPT OBTAINS ITS FIRST CERTIFICATE
@@ -54,17 +57,17 @@ class profile_website::vhost {
     }
 
     $vhost = lookup('apache::vhost', Hash)
-    $ssl_vhost_name = String("${facts['fqdn']}-ssl")
+    $ssl_vhost_name = String("${facts['networking']['fqdn']}-ssl")
     $servername = $vhost[$ssl_vhost_name]['servername']
     $serveraliases = $vhost[$ssl_vhost_name]['serveraliases']
     $docroot = $vhost[$ssl_vhost_name]['docroot']
 
-    apache::vhost { "${facts['fqdn']}-temp-nossl":
+    apache::vhost { "${facts['networking']['fqdn']}-temp-nossl":
       port            => 80,
       servername      => $servername,
       serveraliases   => $serveraliases,
       access_log_pipe => "|/bin/sh -c '/usr/bin/tee \
-        -a /var/log/httpd/${facts['fqdn']}-nossl_access.log' \
+        -a /var/log/httpd/${facts['networking']['fqdn']}-nossl_access.log' \
         |/bin/sh -c '/usr/bin/logger -t httpd -p local6.notice'",
       directories     => [
         { 'path'    => $docroot,
@@ -76,10 +79,32 @@ class profile_website::vhost {
       ],
       docroot         => $docroot,
       error_log_pipe  => "|/bin/sh -c '/usr/bin/tee \
-        -a /var/log/httpd/${facts['fqdn']}-nossl_error.log' \
+        -a /var/log/httpd/${facts['networking']['fqdn']}-nossl_error.log' \
         |/bin/sh -c '/usr/bin/logger -t httpd -p local6.err'",
       before          => Class['letsencrypt'],
     }
   }
-
+  elsif ( ! $profile_website::ssl::enable_letsencrypt and ! empty($profile_website::ssl::certificate_files) ) {
+    # NOT USING LETS ENCYRPT BUT STATIC CERTS AREN'T YET KNOWN BY CUSTOM FACTS YET
+    # THIS IS UNLIKELY TO HAPPEN AS PREVIOUS elsif SHOULD WORK AROUND THIS
+    $notify_text = @("EOT"/)
+      Default SSL certificate and/or key files are currently missing on this host.
+      Presumably this Puppet agent run will install the custom certificates,
+      but they are not yet known by the custom Puppet fact that looks for the certificates.
+      You must run Puppet agent once more to use the custom certificates that are being created.
+      | EOT
+    notify { $notify_text:
+      withpath => true,
+      loglevel => 'warning',
+    }
+  }
+  else {
+    ## UNKNOWN ERROR
+    $notify_text = @("EOT"/)
+      Unknown Error figuring out SSL certificate and/or key files.
+      | EOT
+    notify { $notify_text:
+      withpath => true,
+    }
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
       "version_requirement": ">= 6.21.0 < 8.0.0"
     }
   ],
-  "pdk-version": "2.2.0",
-  "template-url": "pdk-default#2.2.0",
-  "template-ref": "tags/2.2.0-0-g2381db6"
+  "pdk-version": "2.7.1",
+  "template-url": "pdk-default#2.7.4",
+  "template-ref": "tags/2.7.4-0-g58edf57"
 }


### PR DESCRIPTION
Fix #18
Fix #19 

Also:
- Allow kerberos keytab to be disabled #19 
- Update PDK, fix github pdk-validate workflow, fix puppet-lint warnings
- Add README details for supplying own certificates

These changes have been tested on `metrics-test` & `asd-test-web2`.